### PR TITLE
Switch changelog branch

### DIFF
--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -32,4 +32,5 @@ jobs:
           git config user.email "github-actions@github.com"
           git add CHANGELOG.md
           git commit -m "chore: update CHANGELOG for ${{ github.ref_name }}"
-          git push origin HEAD:main
+          git pull origin develop --no-rebase
+          git push origin HEAD:develop


### PR DESCRIPTION
Closes #8

Pushes updates to `develop` instead of `main`